### PR TITLE
fix: crash bugs in community apps

### DIFF
--- a/app-source/Connect/Connect.py
+++ b/app-source/Connect/Connect.py
@@ -118,7 +118,10 @@ async def serve_client(reader, writer):
 
         # Parse HTTP request
         request_line = request_line.decode('utf-8')
-        method, path, _ = request_line.split()
+        parts = request_line.split()
+        if len(parts) < 3:
+            continue
+        method, path, _ = parts[0], parts[1], parts[2]
         
         if path == '/sysinfo' and method == 'GET':
             response = json.dumps(sys_info)

--- a/app-source/KanjiReader/KanjiReader.py
+++ b/app-source/KanjiReader/KanjiReader.py
@@ -55,8 +55,11 @@ kanji = Kanji(tft)
 #     print("Hello world!")
 
 def show_file(fn,idx):
-    fn.seek(idx)
-    buf = fn.read(100)
+    try:
+        fn.seek(idx)
+        buf = fn.read(100)
+    except OSError:
+        return fn.tell()
     buf = buf.replace('\n','').replace('\r','')
     # clear framebuffer 
     tft.fill(config['bg_color'])

--- a/app-source/LowPowerClock/Clock_LE/powermanager.py
+++ b/app-source/LowPowerClock/Clock_LE/powermanager.py
@@ -86,7 +86,7 @@ class SleepManager:
         """Store our state in the RTC memory"""
         # check if we live in the apps path
         path_list = __name__.replace('.','/').split('/')
-        if path_list[0] == "sd" or path_list[1] == "sd":
+        if len(path_list) > 1 and (path_list[0] == "sd" or path_list[1] == "sd"):
             rtcdata = _PATH_HERE_SD + APP_NAME + _SEPARATOR + json.dumps(self.state)
         else:
             rtcdata = _PATH_HERE_FLASH + APP_NAME + _SEPARATOR + json.dumps(self.state)

--- a/app-source/RandomScale/RandomScale/Audio.py
+++ b/app-source/RandomScale/RandomScale/Audio.py
@@ -44,11 +44,13 @@ def generateTriangleWave(freq, volume):
 	sampleIncrement = (math.pi / SAMPLE_RATE) * freq / 2
 	currentIncrement = 0
 	
+	if freq == 0:
+		return bytearray()
 	sampleList = bytearray()
 	period = 1/freq
 	while currentIncrement < period:
 		sample = math.floor( (math.pi * freq) * math.asin(abs(math.sin(math.pi * currentIncrement))) * 127.5 / volume)
-		sampleList = bytearray((sample, sample))
+		sampleList += bytearray((sample, sample))
 		currentIncrement += sampleIncrement
 			
 	return sampleList

--- a/app-source/mmlPlay/mmlPlay.py
+++ b/app-source/mmlPlay/mmlPlay.py
@@ -46,6 +46,8 @@ i2s = machine.I2S(0,
 
 # Generate a square wave buffer
 def generate_square_wave(frequency, duration, volume):
+    if frequency == 0:
+        return bytearray(1024)
     samples = bytearray(1024)
     half_period = int(44100 / (2 * frequency))
     amplitude = int(volume * 32767)
@@ -110,6 +112,7 @@ default_volume = 4
 
 def get_note_frequency(note, octave):
     if note in FREQ_TABLE:
+        octave = max(0, min(len(FREQ_TABLE['C']) - 1, octave))
         return FREQ_TABLE[note][octave]
     return None
 

--- a/app-source/timer/timer.py
+++ b/app-source/timer/timer.py
@@ -171,7 +171,7 @@ def main():
             if time_value != "0":
                 # remove leading 0s
                 time_value = time_value.lstrip("0")
-                if time_value[0] == ".":
+                if time_value and time_value[0] == ".":
                     time_value = "0" + time_value
             redraw = True
 


### PR DESCRIPTION
## Summary

Six crash fixes across five community apps, found during code review. All are edge cases with no impact on normal operation.

### Connect — malformed HTTP request line (`Connect.py`)
`request_line.split()` is unpacked directly into three variables. A malformed or empty request line (fewer than 3 tokens) raises `ValueError`. Added a `len(parts) < 3` guard with `continue` before unpacking.

### LowPowerClock — path_list IndexError (`powermanager.py`)
`path_list[1]` is accessed before checking its length. When `__name__` contains no `.` (single-component module path), `split('/')` produces a one-element list and `path_list[1]` raises `IndexError`. Added `len(path_list) > 1` guard.

### timer — empty string IndexError after lstrip (`timer.py`)
`time_value.lstrip("0")` is called, then `time_value[0]` is checked. If the value was `"0"` (all zeros), `lstrip` produces `""` and `[0]` raises `IndexError`. Added a truthiness guard: `if time_value and time_value[0] == "."`.

### RandomScale — ZeroDivisionError + sample accumulation bug (`Audio.py`)
Two bugs in `generateTriangleWave()`:
1. When `freq == 0`, `1/freq` and the `math.sin` call both raise `ZeroDivisionError`. Added early return with empty `bytearray`.
2. `sampleList = bytearray((sample, sample))` overwrites the list on every iteration instead of appending. Changed to `sampleList += bytearray(...)` so samples actually accumulate.

### mmlPlay — ZeroDivisionError + octave IndexError (`mmlPlay.py`)
1. `generate_square_wave()` divides by `frequency`; rests/silence notes with frequency 0 crash. Guard returns a silent buffer early.
2. `get_note_frequency()` indexes `FREQ_TABLE[note][octave]` with no bounds check. An out-of-range octave value (from malformed MML or edge-case parsing) raises `IndexError`. Clamped to `0..len(FREQ_TABLE['C'])-1`.

### KanjiReader — bare file seek/read (`KanjiReader.py`)
`fn.seek(idx)` and `fn.read(100)` can raise `OSError` if the file is on SD card and the card is removed or the file handle is stale. Wrapped in `try/except OSError` that returns the current position so the caller can continue gracefully.

## Test plan

- [ ] Connect: send a raw TCP connection with a blank line — no crash
- [ ] LowPowerClock: run app installed directly (no subdirectory) — no crash in `store()`
- [ ] timer: type `000` and delete until display shows `0` — no crash
- [ ] RandomScale: trigger a note with frequency 0 — silent, no crash
- [ ] mmlPlay: play MML with a rest (`R`) note — no crash; play with extreme octave value — no crash
- [ ] KanjiReader: remove SD mid-read — graceful skip, no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)